### PR TITLE
fix: 좋아요 버튼에 likeUsers 초기 값 안 넘어가는 문제 해결

### DIFF
--- a/client/src/components/bookJournalList/BookJournalCard.js
+++ b/client/src/components/bookJournalList/BookJournalCard.js
@@ -33,7 +33,7 @@ export default function BookJournalCard({$target, initialState={}}){
       <div class="book-journal-list__tag"><ul>${bookJournal.tags.map( tagId => `<li># ${getTagName(tagId)}</li>`).join('')}</ul></div>
     </div>
     `
-    new LikeButton({$target : this.$element,initialState:{likeCount:bookJournal.likeCount }})
+    new LikeButton({$target : this.$element,initialState:{likeCount:bookJournal.likeCount, likeUsers:bookJournal.likeUsers }})
   }
   this.renderMatchedItem = (keyword, item) => {
     if ( !item.includes(keyword)){


### PR DESCRIPTION
# 📑 개요
좋아요 버튼에 likeUsers 초기 값 안 넘어가는 문제 해결
# 📎 관련 이슈
좋아요 버튼에 likeUsers 초기 값 안 넘어가는 문제 / #29
# 💬 작업 내용
BookJournalCard 컴포넌트에서 LikeButton 컴포넌트로  likeUsers 값을 안넘기고 있어서  추가했습니다.
