### PR TITLE
[#31] design: 장르 select박스 width 100px -> 120px 수정

### DIFF
--- a/client/src/styles/styles.css
+++ b/client/src/styles/styles.css
@@ -31,7 +31,7 @@ li {
 }
 
 select {
-  width: 100px;
+  width: 120px;
   padding: .2em .2em; 
   font-family: inherit;
   font-size: inherit;


### PR DESCRIPTION
# 📑 개요
장르 select 박스가 너비 작아서 글씨가 짤리는 현상 발생 

# 📎 관련 이슈
 BookJournal Page 에서 장르 width 값 늘리기/ [#31]

